### PR TITLE
Fix for Uncaught (in promise) DOMException: The source image cannot be decoded

### DIFF
--- a/src/yall.js
+++ b/src/yall.js
@@ -32,6 +32,8 @@ var yall = function(userOptions) {
           }
 
           element.replaceWith(newImageElement);
+        }).catch(() => {
+          yallFlipDataAttrs(element);
         });
       } else {
         yallFlipDataAttrs(element);


### PR DESCRIPTION
catch image decode fail and fall back to yallFlipDataAttributes(element);  https://github.com/malchata/yall.js/issues/24