### PR TITLE
Bug fix for loading source elements

### DIFF
--- a/src/yall.mjs
+++ b/src/yall.mjs
@@ -21,17 +21,15 @@ export default function (options) {
   // This function handles lazy loading of elements.
   const yallLoad = element => {
     const parentNode = element.parentNode;
-    let sourceNode;
 
     if (parentNode.nodeName == "PICTURE") {
-      sourceNode = parentNode;
+      yallApplyFn(queryDOM("source", parentNode), yallFlipDataAttrs);
     }
 
     if (element.nodeName == "VIDEO") {
-      sourceNode = element;
+      yallApplyFn(queryDOM("source", element), yallFlipDataAttrs);
     }
-
-    yallApplyFn(queryDOM("source", sourceNode), yallFlipDataAttrs);
+    
     yallFlipDataAttrs(element);
 
     if (element.autoplay) {


### PR DESCRIPTION
At present, lazy-loading any `<img>` element that is not in a `<picture>` element causes _all_ `<source>` elements on the page to be lazy-loaded.
see https://codepen.io/QcodePeter/pen/YzPWxgY
This fixes the bug by only loading `<source>` elements within the same `<picture>` as `element`, or in `element` if `element` is a `<video>`.