### PR TITLE
Replaces yall.mjs to yall.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Yet Another Lazy Loader",
   "type": "module",
   "source": "./src/index.js",
-  "exports": "./dist/yall.mjs",
+  "exports": "./dist/yall.js",
   "main": "./dist/yall.cjs",
   "module": "./dist/yall.js",
   "unpkg": "./dist/yall.umd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yall-js",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Yet Another Lazy Loader",
   "type": "module",
   "source": "./src/index.js",


### PR DESCRIPTION
Resolves https://github.com/malchata/yall.js/issues/97

The npm package `exports` looks up for `./dist/yall.mjs`, however that file does not exist in the library. Workarounds are made from the end-user by adding a renaming command such as this one:

```
"postinstall": "sed -i 's#./dist/yall.mjs#./dist/yall.js#' node_modules/yall-js/package.json"
```

This PR aims at removing the burden from the end-user in renaming the file to the correct export.